### PR TITLE
Update recipient metadata array key

### DIFF
--- a/src/Mandrill/Struct/Message.php
+++ b/src/Mandrill/Struct/Message.php
@@ -269,7 +269,7 @@ class Message extends Struct{
         );
         $this->recipient_metadata[] = array(
             'rcpt' => $recipient->email,
-            'vars' => $recipient->getMetadata()
+            'values' => $recipient->getMetadata()
         );
         return $this;
     }


### PR DESCRIPTION
Based on Mandrill's documentation (https://mandrillapp.com/api/docs/messages.php.html#method=send) `recipient_metedata` is expecting an array key of `values` not `vars`.
