### PR TITLE
Add type to recipient and use this in the message struct

### DIFF
--- a/src/Mandrill/Struct/Message.php
+++ b/src/Mandrill/Struct/Message.php
@@ -261,7 +261,8 @@ class Message extends Struct{
     public function addRecipient(Recipient $recipient){
         $this->to[] = array(
             'email' => $recipient->email,
-            'name' => $recipient->name
+            'name' => $recipient->name,
+            'type' => $recipient->type
         );
         $this->merge_vars[] = array(
             'rcpt' => $recipient->email,

--- a/src/Mandrill/Struct/Recipient.php
+++ b/src/Mandrill/Struct/Recipient.php
@@ -21,6 +21,11 @@ class Recipient extends Struct{
     public $name;
 
     /**
+     * @var string the recipient's header type i.e. 'to', 'cc', 'bcc'
+     */
+    public $type = 'to';
+
+    /**
      * @var array associative array of recipient-specific merge variables
      */
     protected $merge_vars = array();
@@ -33,13 +38,17 @@ class Recipient extends Struct{
     /**
      * @param string $email the recipient's email address
      * @param string $name the recipient's name
+     * @param string $type the recipient's header type i.e. 'to', 'cc', 'bcc'
      */
-    function __construct($email = NULL, $name = NULL){
+    function __construct($email = NULL, $name = NULL, $type = NULL){
         if(!is_null($email)){
             $this->email = $email;
         }
         if(!is_null($name)){
             $this->name = $name;
+        }
+        if(!is_null($type)){
+            $this->type = $type;
         }
     }
 


### PR DESCRIPTION
Hey @jlinn,

I noticed that there was no way of setting the recipient type e.g. `to`, `cc` etc. Hope this is ok!

Thanks.
